### PR TITLE
Enable LLVM for i386

### DIFF
--- a/packages/lang/llvm/package.mk
+++ b/packages/lang/llvm/package.mk
@@ -19,7 +19,7 @@
 PKG_NAME="llvm"
 PKG_VERSION="3.9.0"
 PKG_REV="1"
-PKG_ARCH="x86_64"
+PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://llvm.org/"
 PKG_URL="http://llvm.org/releases/$PKG_VERSION/${PKG_NAME}-${PKG_VERSION}.src.tar.xz"


### PR DESCRIPTION
Otherwise Mesa won't compile.