### PR TITLE
WeTek Hub and WeTek Play 2 fixes

### DIFF
--- a/projects/WeTek_Hub/filesystem/etc/asound.conf
+++ b/projects/WeTek_Hub/filesystem/etc/asound.conf
@@ -1,0 +1,11 @@
+pcm.!default {
+        type hw
+        card 0
+        device 0
+        format S16_LE
+}
+
+ctl.!default {
+        type hw
+        card 0
+}

--- a/projects/WeTek_Hub/initramfs/platform_init
+++ b/projects/WeTek_Hub/initramfs/platform_init
@@ -41,27 +41,25 @@ echo 0 > /sys/class/graphics/fb1/free_scale
 # set initial video state
 echo 1 > /sys/class/video/disable_video
 
-# Set framebuffer geometry to match the resolution
-case $hdmimode in
-  480*)            X=720  Y=480  ;;
-  576*)            X=720  Y=576  ;;
-  720p*)           X=1280 Y=720  ;;
-  *)               X=1920 Y=1080 ;;
-esac
-
-fbset -fb /dev/fb0 -g $X $Y 1920 2160 32
+# Set framebuffer geometry to 1920x1080
+fbset -fb /dev/fb0 -g 1920 1080 1920 2160 32
 fbset -fb /dev/fb1 -g 32 32 32 32 32
 
-# Enable scaling for 4K output
+# Enable scaling for all resolutions except of 1920x1080
 case $hdmimode in
-  4k*|smpte*|2160*)
-    echo 0 0 1919 1079 > /sys/class/graphics/fb0/free_scale_axis
-    echo 0 0 3839 2159 > /sys/class/graphics/fb0/window_axis
-    echo 1920 > /sys/class/graphics/fb0/scale_width
-    echo 1080 > /sys/class/graphics/fb0/scale_height
-    echo 0x10001 > /sys/class/graphics/fb0/free_scale
-  ;;
+  480*)             width=719  height=479  ;;
+  576*)             width=719  height=575  ;;
+  720p*)            width=1279 height=719  ;;
+  4k*|smpte*|2160*) width=3839 height=2159 ;;
 esac
+
+if [ -n $width -a -n $height ]; then
+  echo 0 0 1919 1079 > /sys/class/graphics/fb0/free_scale_axis
+  echo 0 0 $width $height > /sys/class/graphics/fb0/window_axis
+  echo 1920 > /sys/class/graphics/fb0/scale_width
+  echo 1080 > /sys/class/graphics/fb0/scale_height
+  echo 0x10001 > /sys/class/graphics/fb0/free_scale
+fi
 
 # Include deinterlacer into default VFM map
 echo rm default > /sys/class/vfm/map

--- a/projects/WeTek_Play_2/filesystem/etc/asound.conf
+++ b/projects/WeTek_Play_2/filesystem/etc/asound.conf
@@ -1,0 +1,11 @@
+pcm.!default {
+        type hw
+        card 0
+        device 0
+        format S16_LE
+}
+
+ctl.!default {
+        type hw
+        card 0
+}

--- a/projects/WeTek_Play_2/initramfs/platform_init
+++ b/projects/WeTek_Play_2/initramfs/platform_init
@@ -1,20 +1,20 @@
 #!/bin/sh
 ################################################################################
-#      This file is part of LibreELEC - https://LibreELEC.tv
-#      Copyright (C) 2016 Team LibreELEC
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2009-2016 Stephan Raue (stephan@openelec.tv)
 #
-#  LibreELEC is free software: you can redistribute it and/or modify
+#  OpenELEC is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 2 of the License, or
 #  (at your option) any later version.
 #
-#  LibreELEC is distributed in the hope that it will be useful,
+#  OpenELEC is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+#  along with OpenELEC.  If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
 
 hdmimode=1080p60hz
@@ -41,27 +41,25 @@ echo 0 > /sys/class/graphics/fb1/free_scale
 # set initial video state
 echo 1 > /sys/class/video/disable_video
 
-# Set framebuffer geometry to match the resolution
-case $hdmimode in
-  480*)            X=720  Y=480  ;;
-  576*)            X=720  Y=576  ;;
-  720p*)           X=1280 Y=720  ;;
-  *)               X=1920 Y=1080 ;;
-esac
-
-fbset -fb /dev/fb0 -g $X $Y 1920 2160 32
+# Set framebuffer geometry to 1920x1080
+fbset -fb /dev/fb0 -g 1920 1080 1920 2160 32
 fbset -fb /dev/fb1 -g 32 32 32 32 32
 
-# Enable scaling for 4K output
+# Enable scaling for all resolutions except of 1920x1080
 case $hdmimode in
-  4k*|smpte*|2160*)
-    echo 0 0 1919 1079 > /sys/class/graphics/fb0/free_scale_axis
-    echo 0 0 3839 2159 > /sys/class/graphics/fb0/window_axis
-    echo 1920 > /sys/class/graphics/fb0/scale_width
-    echo 1080 > /sys/class/graphics/fb0/scale_height
-    echo 0x10001 > /sys/class/graphics/fb0/free_scale
-  ;;
+  480*)             width=719  height=479  ;;
+  576*)             width=719  height=575  ;;
+  720p*)            width=1279 height=719  ;;
+  4k*|smpte*|2160*) width=3839 height=2159 ;;
 esac
+
+if [ -n $width -a -n $height ]; then
+  echo 0 0 1919 1079 > /sys/class/graphics/fb0/free_scale_axis
+  echo 0 0 $width $height > /sys/class/graphics/fb0/window_axis
+  echo 1920 > /sys/class/graphics/fb0/scale_width
+  echo 1080 > /sys/class/graphics/fb0/scale_height
+  echo 0x10001 > /sys/class/graphics/fb0/free_scale
+fi
 
 # Include deinterlacer into default VFM map
 echo rm default > /sys/class/vfm/map


### PR DESCRIPTION
Fix the following issues on WeTek Hub and WeTek Play 2:
* Garbled screen output for resolutions other than 1920x1080.
* No sound.


