### PR TITLE
Rules for Shield Controller

### DIFF
--- a/packages/libretro/retroarch/udev.d/99-nv-shield-controller.rules
+++ b/packages/libretro/retroarch/udev.d/99-nv-shield-controller.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="input", ATTRS{idVendor}=="0955", ATTRS{idProduct}=="7210", MODE="0666", ENV{ID_INPUT_JOYSTICK}="1", ENV{ID_INPUT_MOUSE}=""


### PR DESCRIPTION
See libretro/Lakka#379. Update udev rules to use the pre-2017 Shield Controller.